### PR TITLE
Accept array for job settings parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1 - Unreleased
+
+### Fixed 
+
+- Fixed an error when passing an array of settings to the `addJob` service method. [#5](https://github.com/verbb/scheduler/issues/5)
+
 ## 3.0.0 - 2023-12-28
 > {note} The plugin’s package name has changed to `verbb/scheduler`. Scheduler will need be updated to 3.0 from a terminal, by running `composer require verbb/scheduler && composer remove supercool/scheduler`.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "verbb/scheduler",
     "description": "Schedule jobs to be executed on a given date.",
     "type": "craft-plugin",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/models/Job.php
+++ b/src/models/Job.php
@@ -18,7 +18,7 @@ class Job extends Model
     public ?string $type = null;
     public ?DateTime $date = null;
     public ?string $context = null;
-    public ?string $settings = null;
+    public null|string|array $settings = null;
 
     private mixed $_jobType = null;
 


### PR DESCRIPTION
Backport of the fix for a [syntax error when scheduling jobs](https://github.com/verbb/scheduler/issues/5) from the Craft 5 branch.