### PR TITLE
console: actually end when _end() is called

### DIFF
--- a/src/console/controllers/CommandController.php
+++ b/src/console/controllers/CommandController.php
@@ -22,7 +22,7 @@ class CommandController extends Controller
     // Public Methods
     // =========================================================================
 
-    public function actionRun(): void
+    public function actionRun(): int
     {
         $sep = PHP_EOL . "------------------------------" . PHP_EOL;
         echo PHP_EOL . "Checking scheduled jobs ..." . PHP_EOL;
@@ -34,14 +34,14 @@ class CommandController extends Controller
         // If it is actually a date, then work out if we need to exit
         if ($nextJobDate instanceof DateTime) {
             if ($nextJobDate->getTimestamp() > DateTimeHelper::currentTimeStamp()) {
-                $this->_end("The next job is at " . $nextJobDate->format('c'));
+                return $this->_end("The next job is at " . $nextJobDate->format('c'));
             } else {
                 Craft::$app->getCache()->delete('scheduler_nextjobdate');
             }
         } else if ($nextJobDate == 'nodate') {
             // If there are no dates then bail - that will be busted when a new one is
             // added or the cache expires
-            $this->_end();
+            return $this->_end();
         } else {
             // If we got this far then we need to check the next job
             // Get the date of the next job
@@ -51,19 +51,19 @@ class CommandController extends Controller
             // to true - it will be busted if a job is ever saved
             if (!$nextJobDate) {
                 Craft::$app->getCache()->set('scheduler_nextjobdate', 'nodate');
-                $this->_end();
+                return $this->_end();
             }
 
             // If the next job date is in the future, then set the cache and end
             if ($nextJobDate->getTimestamp() > DateTimeHelper::currentTimeStamp()) {
                 Craft::$app->getCache()->set('scheduler_nextjobdate', $nextJobDate);
-                $this->_end("The next job is at " . $nextJobDate->format('c'));
+                return $this->_end("The next job is at " . $nextJobDate->format('c'));
             }
         }
 
         // If we got this far then there must be overdue jobs so get and loop them
         $jobs = Scheduler::$plugin->getJobs()->getOverdueJobs();
-        
+
         if ($jobs) {
             echo $sep;
 
@@ -87,9 +87,9 @@ class CommandController extends Controller
                 echo $sep;
             }
 
-            $this->_end('Schedule complete.');
+            return $this->_end('Schedule complete.');
         } else {
-            $this->_end();
+            return $this->_end();
         }
     }
 


### PR DESCRIPTION
Fixes errors like

```
Checking scheduled jobs ...

No jobs are due to run.
Exception 'Error' with message 'Call to a member function getTimestamp() on bool'

in /var/www/html/vendor/verbb/scheduler/src/console/controllers/CommandController.php:58

Stack trace:
#0 [internal function]: verbb\scheduler\console\controllers\CommandController->actionRun()
#1 /var/www/html/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#2 /var/www/html/vendor/yiisoft/yii2/base/Controller.php(178): yii\base\InlineAction->runWithParams(Array)
#3 /var/www/html/vendor/yiisoft/yii2/console/Controller.php(180): yii\base\Controller->runAction('run', Array)
#4 /var/www/html/vendor/yiisoft/yii2/base/Module.php(552): yii\console\Controller->runAction('run', Array)
#5 /var/www/html/vendor/yiisoft/yii2/console/Application.php(180): yii\base\Module->runAction('scheduler/comma...', Array)
#6 /var/www/html/vendor/craftcms/cms/src/console/Application.php(91): yii\console\Application->runAction('scheduler/comma...', Array)
#7 /var/www/html/vendor/yiisoft/yii2/console/Application.php(147): craft\console\Application->runAction('scheduler/comma...', Array)
#8 /var/www/html/vendor/craftcms/cms/src/console/Application.php(122): yii\console\Application->handleRequest(Object(craft\console\Request))
#9 /var/www/html/vendor/yiisoft/yii2/base/Application.php(384): craft\console\Application->handleRequest(Object(craft\console\Request))
#10 /var/www/html/craft(13): yii\base\Application->run()
#11 {main}

```


Should I backport this fix to Craft 3/4, too?